### PR TITLE
Fix #4: remove duplicate FastAPI route blocking index page

### DIFF
--- a/fastapi_radar/radar.py
+++ b/fastapi_radar/radar.py
@@ -120,7 +120,6 @@ class Radar:
 
         # Add a catch-all route for the dashboard SPA
         # This ensures all sub-routes under /__radar serve the index.html
-        @self.app.get(f"{self.dashboard_path}")
         @self.app.get(f"{self.dashboard_path}/{{full_path:path}}")
         async def serve_dashboard(request: Request, full_path: str = ""):
             # Check if it's a request for a static asset


### PR DESCRIPTION
Patchfix this issue : https://github.com/doganarif/fastapi-radar/issues/4

<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed a duplicate FastAPI GET route that was blocking the dashboard index at /__radar. Fixes #4 and ensures /__radar and its subpaths serve the SPA index correctly.

- **Bug Fixes**
  - Removed the exact route for dashboard_path so the catch-all {full_path:path} handles /__radar and subpaths.
  - Index and static assets now load as expected.

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Bug Fixes:
- Eliminate duplicate GET route for dashboard_path to unblock the SPA index page and allow catch-all route to handle all subpaths