### PR TITLE
Move some libs to dev dependencies to lighten install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,6 @@ dependencies = [
     "sqlalchemy>=1.4.0",
     "pydantic>=1.8.0",
     "starlette>=0.14.2",
-    "black>=24.8.0",
-    "httpx>=0.28.1",
 ]
 
 [project.urls]
@@ -49,6 +47,7 @@ dev = [
     "isort>=5.10.0",
     "flake8>=4.0.0",
     "mypy>=0.950",
+    "httpx>=0.28.1",
 ]
 
 [build-system]


### PR DESCRIPTION
I noticed that httpx and black were being installed even though they are dependencies of dev/tests.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved httpx to the dev extra and removed black from runtime dependencies to reduce install size and avoid pulling dev/test tools into production.

- **Dependencies**
  - Removed black from project dependencies.
  - Added httpx to the dev extra.

- **Migration**
  - If your workflow expects black, install it separately or add it to your dev setup.

<!-- End of auto-generated description by cubic. -->

