### PR TITLE
Query parameters should be a dict instead of list

### DIFF
--- a/fastapi_radar/api.py
+++ b/fastapi_radar/api.py
@@ -52,7 +52,7 @@ class QueryDetail(BaseModel):
     id: int
     request_id: str
     sql: str
-    parameters: Optional[List[Any]]
+    parameters: Optional[Dict[str, Any]]
     duration_ms: Optional[float]
     rows_affected: Optional[int]
     connection_name: Optional[str]


### PR DESCRIPTION
When I access http://127.0.0.1:8000/__radar/database, I got following error:

```
  File "D:\github\myproject\.venv\Lib\site-packages\fastapi_radar\api.py", line 214, in get_queries
    QueryDetail(
    ~~~~~~~~~~~^
        id=q.id,
        ^^^^^^^^
    ...<6 lines>...
        created_at=q.created_at,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "D:\github\myproject\.venv\Lib\site-packages\pydantic\main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for QueryDetail
parameters
  Input should be a valid list [type=list_type, input_value={'created_by_1': '1102085...': '0', 'param_2': '50'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/list_type
```

The query parameters should be a dict instead of a dict.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a Pydantic validation error on /__radar/database by changing QueryDetail.parameters from a list to a dict to match the real query parameter shape. This aligns the model with actual data and prevents the page from erroring.

<!-- End of auto-generated description by cubic. -->

