### PR TITLE
feat: add `include_in_schema` argument to Radar init

### DIFF
--- a/fastapi_radar/api.py
+++ b/fastapi_radar/api.py
@@ -1,13 +1,14 @@
 """API endpoints for FastAPI Radar dashboard."""
 
-from typing import Optional, List, Dict, Any
 from datetime import datetime, timedelta
-from fastapi import APIRouter, Query, Depends, HTTPException
-from sqlalchemy.orm import Session
-from sqlalchemy import desc
-from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
 
-from .models import CapturedRequest, CapturedQuery, CapturedException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from .models import CapturedException, CapturedQuery, CapturedRequest
 
 
 def round_float(value: Optional[float], decimals: int = 2) -> Optional[float]:

--- a/fastapi_radar/capture.py
+++ b/fastapi_radar/capture.py
@@ -1,7 +1,8 @@
 """SQLAlchemy query capture for FastAPI Radar."""
 
 import time
-from typing import Any, Optional, Callable
+from typing import Any, Callable, Optional
+
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 

--- a/fastapi_radar/middleware.py
+++ b/fastapi_radar/middleware.py
@@ -4,13 +4,15 @@ import json
 import time
 import traceback
 import uuid
-from typing import Optional, Callable
 from contextvars import ContextVar
+from typing import Callable, Optional
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
-from .models import CapturedRequest, CapturedException
-from .utils import serialize_headers, get_client_ip, truncate_body
+
+from .models import CapturedException, CapturedRequest
+from .utils import get_client_ip, serialize_headers, truncate_body
 
 request_context: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
 

--- a/fastapi_radar/models.py
+++ b/fastapi_radar/models.py
@@ -1,7 +1,8 @@
 """Storage models for FastAPI Radar."""
 
 from datetime import datetime
-from sqlalchemy import Column, String, Integer, Float, Text, DateTime, ForeignKey, JSON
+
+from sqlalchemy import JSON, Column, DateTime, Float, ForeignKey, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 

--- a/fastapi_radar/radar.py
+++ b/fastapi_radar/radar.py
@@ -1,17 +1,18 @@
 """Main Radar class for FastAPI Radar."""
 
-from typing import Optional, List
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
+from typing import List, Optional
+
 from fastapi import FastAPI
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import Session, sessionmaker
 
-from .models import Base
-from .middleware import RadarMiddleware
-from .capture import QueryCapture
 from .api import create_api_router
+from .capture import QueryCapture
+from .middleware import RadarMiddleware
+from .models import Base
 
 
 class Radar:
@@ -28,6 +29,7 @@ class Radar:
         slow_query_threshold: int = 100,
         capture_sql_bindings: bool = True,
         exclude_paths: Optional[List[str]] = None,
+        include_in_schema: bool = True,
         theme: str = "auto",
     ):
         self.app = app
@@ -69,8 +71,8 @@ class Radar:
         if self.db_engine:
             self._setup_query_capture()
 
-        self._setup_api()
-        self._setup_dashboard()
+        self._setup_api(include_in_schema=include_in_schema)
+        self._setup_dashboard(include_in_schema=include_in_schema)
 
     @contextmanager
     def get_session(self) -> Session:
@@ -104,15 +106,15 @@ class Radar:
         )
         self.query_capture.register(self.db_engine)
 
-    def _setup_api(self) -> None:
+    def _setup_api(self, include_in_schema: bool) -> None:
         """Mount API endpoints."""
         api_router = create_api_router(self.get_session)
-        self.app.include_router(api_router)
+        self.app.include_router(api_router, include_in_schema=include_in_schema)
 
-    def _setup_dashboard(self) -> None:
+    def _setup_dashboard(self, include_in_schema: bool) -> None:
         """Mount dashboard static files."""
-        from fastapi.responses import FileResponse
         from fastapi import Request
+        from fastapi.responses import FileResponse
 
         dashboard_dir = Path(__file__).parent / "dashboard" / "dist"
 
@@ -131,7 +133,10 @@ class Radar:
 
         # Add a catch-all route for the dashboard SPA
         # This ensures all sub-routes under /__radar serve the index.html
-        @self.app.get(f"{self.dashboard_path}/{{full_path:path}}")
+        @self.app.get(
+            f"{self.dashboard_path}/{{full_path:path}}",
+            include_in_schema=include_in_schema,
+        )
         async def serve_dashboard(request: Request, full_path: str = ""):
             # Check if it's a request for a static asset
             if full_path and any(
@@ -292,6 +297,7 @@ class Radar:
     def cleanup(self, older_than_hours: Optional[int] = None) -> None:
         """Clean up old captured data."""
         from datetime import datetime, timedelta
+
         from .models import CapturedRequest
 
         with self.get_session() as session:

--- a/fastapi_radar/radar.py
+++ b/fastapi_radar/radar.py
@@ -29,8 +29,8 @@ class Radar:
         slow_query_threshold: int = 100,
         capture_sql_bindings: bool = True,
         exclude_paths: Optional[List[str]] = None,
-        include_in_schema: bool = True,
         theme: str = "auto",
+        include_in_schema: bool = True,
     ):
         self.app = app
         self.db_engine = db_engine

--- a/fastapi_radar/utils.py
+++ b/fastapi_radar/utils.py
@@ -1,8 +1,9 @@
 """Utility functions for FastAPI Radar."""
 
 from typing import Dict, Optional
-from starlette.requests import Request
+
 from starlette.datastructures import Headers
+from starlette.requests import Request
 
 
 def serialize_headers(headers: Headers) -> Dict[str, str]:


### PR DESCRIPTION
This PR add `include_in_schema` argument to `__init__` Radar for hide route if need,
With `include_in_schema at True (default for no breaking change)
```example.py
...
radar = Radar(
    app,
    db_engine=engine,
    dashboard_path="/__radar",
    slow_query_threshold=50,
    theme="auto",
)
...
```

<img width="1460" height="897" alt="image" src="https://github.com/user-attachments/assets/e88350b4-3b67-4fa8-a8f5-e0f05a33f5ec" />

---
With `include_in_schema` at False
```example.py
...
radar = Radar(
    app,
    db_engine=engine,
    dashboard_path="/__radar",
    slow_query_threshold=50,
    theme="auto",
    include_in_schema=False,
)
...
```

<img width="1463" height="902" alt="image" src="https://github.com/user-attachments/assets/bdba9d01-407f-4388-aba7-ec4677419fc3" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an include_in_schema option to Radar to control whether Radar API and dashboard routes appear in the OpenAPI schema and Swagger UI. Defaults to True to avoid breaking changes.

- **New Features**
  - Added include_in_schema: bool to Radar(...), default True.
  - API router and dashboard catch-all route honor include_in_schema; set False to hide them from docs.

<!-- End of auto-generated description by cubic. -->

