### PR TITLE
Fix issue with active connections being dropped when data is cleared

### DIFF
--- a/fastapi_radar/middleware.py
+++ b/fastapi_radar/middleware.py
@@ -7,7 +7,7 @@ import uuid
 from contextvars import ContextVar
 from typing import Callable, Optional
 
-from sqlalchemy.orm.exc import ObjectDeletedError
+from sqlalchemy.exc import SQLAlchemyError
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
@@ -131,7 +131,7 @@ class RadarMiddleware(BaseHTTPMiddleware):
                                     )
                                     session.add(captured_request)
                                     session.commit()
-                            except ObjectDeletedError:
+                            except SQLAlchemyError:
                                 # CapturedRequest record has been deleted.
                                 capturing = False
                             else:


### PR DESCRIPTION
If an activate connection is ongoing, in particular with streaming data (e.g. SSE), clearing the capture data causes a database error, dropping the active connection.

This change now catches the exception and stops attempting to capture data, whilst leaving the ongoing stream in place.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes dropped streaming connections when capture data is cleared by halting capture on deleted records while keeping the stream running. Prevents database errors and keeps SSE/streaming responses alive.

- **Bug Fixes**
  - Catch ObjectDeletedError during streaming capture and stop DB writes if the CapturedRequest is deleted.
  - Add a capturing flag to cease capture when deleted or after max_body_size, while continuing to yield stream chunks.

<!-- End of auto-generated description by cubic. -->

